### PR TITLE
Fix a typo

### DIFF
--- a/src/N4447/1-intro.tex
+++ b/src/N4447/1-intro.tex
@@ -15,9 +15,9 @@
 \begin{enumerate}
 \item Overview of the new three instructions:
 \begin{itemize}
-\item \texttt{typedef<T, C>} that expands the definition of type T into a parameter back instantiation. 
-\item \texttt{typename<T, C>} that expands types of the definition of type T into a parameter back. 
-\item \texttt{typeid<T, C>} that expands members names of type T into a parameter back instantiation. 
+\item \texttt{typedef<T, C>} that expands the definition of type T into a parameter pack instantiation. 
+\item \texttt{typename<T, C>} that expands types of the definition of type T into a parameter pack. 
+\item \texttt{typeid<T, C>} that expands members names of type T into a parameter pack instantiation. 
 \end{itemize}
 \item Simple Sample Code
 \begin{codeblock}


### PR DESCRIPTION
I _think_ it was supposed to be `parameter pack` and not `back`.
